### PR TITLE
netlink.cabal: add hsc2hs

### DIFF
--- a/netlink.cabal
+++ b/netlink.cabal
@@ -113,6 +113,7 @@ Library
                      System.Linux.Netlink.GeNetlink.NL80211.WifiEI
   Other-modules:     System.Linux.Netlink.C
   default-language: Haskell2010
+  Build-tools:       hsc2hs
   Build-depends:     base >=4 && <5,
                      bytestring >=0.9,
                      cereal >=0.3,


### PR DESCRIPTION
Otherwise I have in haskell-ide-engine:
Could not find module ‘System.Linux.Netlink.C’  Use -v to see a list of the files searched for.